### PR TITLE
Change datefmt to match ISO 8601

### DIFF
--- a/Releases/Linux/start.py
+++ b/Releases/Linux/start.py
@@ -13,7 +13,7 @@ init()
 
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
 
-logging.basicConfig(filename="idlemaster.log",filemode="w",format="[ %(asctime)s ] %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p",level=logging.DEBUG)
+logging.basicConfig(filename="idlemaster.log",filemode="w",format="[ %(asctime)s ] %(message)s", datefmt="%Y-%m-%d %H:%M:%S",level=logging.DEBUG)
 console = logging.StreamHandler()
 console.setLevel(logging.WARNING)
 console.setFormatter(logging.Formatter("[ %(asctime)s ] %(message)s", "%m/%d/%Y %I:%M:%S %p"))

--- a/Source/Idle Master/start.py
+++ b/Source/Idle Master/start.py
@@ -13,7 +13,7 @@ init()
 
 os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
 
-logging.basicConfig(filename="idlemaster.log",filemode="w",format="[ %(asctime)s ] %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p",level=logging.DEBUG)
+logging.basicConfig(filename="idlemaster.log",filemode="w",format="[ %(asctime)s ] %(message)s", datefmt="%Y-%m-%d %H:%M:%S",level=logging.DEBUG)
 console = logging.StreamHandler()
 console.setLevel(logging.WARNING)
 console.setFormatter(logging.Formatter("[ %(asctime)s ] %(message)s", "%m/%d/%Y %I:%M:%S %p"))


### PR DESCRIPTION
[Date](http://en.wikipedia.org/wiki/ISO_8601#Calendar_dates) and [time](http://en.wikipedia.org/wiki/ISO_8601#Times)

This change also saves 3 characters in the console / log as AM / PM is no longer needed.