### PR TITLE
Remove unicode characters in AppNames when displaying

### DIFF
--- a/Source/Idle Master/start.py
+++ b/Source/Idle Master/start.py
@@ -116,7 +116,7 @@ def getAppName(appID):
 	try:
 		api = requests.get("http://store.steampowered.com/api/appdetails/?appids=" + str(appID) + "&filters=basic")
 		api_data = json.loads(api.text)
-		return Fore.CYAN + str(unicode(api_data[str(appID)]["data"]["name"])) + Fore.RESET
+		return Fore.CYAN + api_data[str(appID)]["data"]["name"].encode('ascii', 'ignore') + Fore.RESET
 	except:
 		return Fore.CYAN + "App "+str(appID) + Fore.RESET
 
@@ -124,7 +124,7 @@ def getPlainAppName(appid):
 	try:
 		api = requests.get("http://store.steampowered.com/api/appdetails/?appids=" + str(appID) + "&filters=basic")
 		api_data = json.loads(api.text)
-		return str(unicode(api_data[str(appID)]["data"]["name"]))
+		return api_data[str(appID)]["data"]["name"].encode('ascii', 'ignore')
 	except:
 		return "App "+str(appID)
 


### PR DESCRIPTION
Two known test cases:

Age of Empires III (contains :copyright:):

```
>>> api = requests.get("http://store.steampowered.com/api/appdetails/?appids=105450&filters=basic")
>>> a = json.loads(api.text)
>>> a[str("105450")]["data"]["name"]
u'Age of Empires\xae III: Complete Collection'
>>> str(unicode(a[str("105450")]["data"]["name"]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xae' in position 14: ordinal not in range(128)
>>> a[str("105450")]["data"]["name"].encode('ascii','ignore')
'Age of Empires III: Complete Collection'
>>> type(a[str("105450")]["data"]["name"].encode('ascii','ignore'))
<type 'str'>
```

Batman: Arkham Origins (contains :tm:)

```
>>> api = requests.get("http://store.steampowered.com/api/appdetails/?appids=209000&filters=basic")
>>> a = json.loads(api.text)
>>> a[str("209000")]["data"]["name"]
u'Batman\u2122: Arkham Origins'
>>> str(unicode(a[str("209000")]["data"]["name"]))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2122' in position 6: ordinal not in range(128)
>>> a[str("209000")]["data"]["name"].encode('ascii','ignore')
'Batman: Arkham Origins'
```

When running current version of Idle Master, for the first case (AoE III) I get (due the above error):
`[ 12/19/2014 11:08:30 PM ] App 105450 has 1 card drops remaining`
