### PR TITLE
Point to correct interpreter

### DIFF
--- a/Python (non-Windows)/Linux/start.py
+++ b/Python (non-Windows)/Linux/start.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 import requests
 import cookielib
 import bs4


### PR DESCRIPTION
While there seems to be version checking in the main script, this returns a syntax error when being started with python3 (the default python version on most linux distributions). It's good practice to put this at the start of any script anyways.