### PR TITLE
Point to correct interpreter

### DIFF
--- a/Python (non-Windows)/Linux/start.py
+++ b/Python (non-Windows)/Linux/start.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2
 import requests
 import cookielib
 import bs4


### PR DESCRIPTION
Botched the last pull request; just a minor typo. Script returns syntax error when started with python3; which is the default python version on most linux distributions. It's good practice to put a hashbang comment at the start of your scripts anyways. 