### PR TITLE
Adding new cookies for the session not being overthrown by web browser session.

### DIFF
--- a/Source/IdleMaster/CookieClient.cs
+++ b/Source/IdleMaster/CookieClient.cs
@@ -36,6 +36,8 @@ namespace IdleMaster
                     Settings.Default.sessionid = string.Empty;
                     Settings.Default.steamLogin = string.Empty;
                     Settings.Default.steamparental = string.Empty;
+                    Settings.Default.steamMachineAuth = string.Empty;
+                    Settings.Default.steamRememberLogin = string.Empty;
                     Settings.Default.Save();
                 }
             }
@@ -51,7 +53,16 @@ namespace IdleMaster
             cookies.Add(new Cookie("sessionid", Settings.Default.sessionid) { Domain = target.Host });
             cookies.Add(new Cookie("steamLogin", Settings.Default.steamLogin) { Domain = target.Host });
             cookies.Add(new Cookie("steamparental", Settings.Default.steamparental) { Domain = target.Host });
+            cookies.Add(new Cookie("steamRememberLogin", Settings.Default.steamRememberLogin) { Domain = target.Host });
+            cookies.Add(new Cookie(GetSteamMachineAuthCookieName(), Settings.Default.steamMachineAuth) { Domain = target.Host });
             return cookies;
+        }
+
+        public static string GetSteamMachineAuthCookieName()
+        {
+            if (Settings.Default.steamLogin != null && Settings.Default.steamLogin.Length > 17)
+                return string.Format("steamMachineAuth{0}", Settings.Default.steamLogin.Substring(0, 17));
+            return "steamMachineAuth";
         }
 
         public static async Task<string> GetHttpAsync(string url, int count = 3)

--- a/Source/IdleMaster/Properties/Settings.Designer.cs
+++ b/Source/IdleMaster/Properties/Settings.Designer.cs
@@ -156,5 +156,29 @@ namespace IdleMaster.Properties {
                 this["OnlyOneGameIdle"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string steamRememberLogin {
+            get {
+                return ((string)(this["steamRememberLogin"]));
+            }
+            set {
+                this["steamRememberLogin"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string steamMachineAuth {
+            get {
+                return ((string)(this["steamMachineAuth"]));
+            }
+            set {
+                this["steamMachineAuth"] = value;
+            }
+        }
     }
 }

--- a/Source/IdleMaster/Properties/Settings.settings
+++ b/Source/IdleMaster/Properties/Settings.settings
@@ -38,5 +38,11 @@
     <Setting Name="OnlyOneGameIdle" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="steamRememberLogin" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="steamMachineAuth" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Source/IdleMaster/app.config
+++ b/Source/IdleMaster/app.config
@@ -45,6 +45,12 @@
             <setting name="OnlyOneGameIdle" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="steamRememberLogin" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="steamMachineAuth" serializeAs="String">
+                <value />
+            </setting>
         </IdleMaster.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Source/IdleMaster/frmBrowser.cs
+++ b/Source/IdleMaster/frmBrowser.cs
@@ -33,6 +33,7 @@ namespace IdleMaster
       InternetSetCookie("http://steamcommunity.com", "sessionid", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
       InternetSetCookie("http://steamcommunity.com", "steamLogin", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
       InternetSetCookie("http://steamcommunity.com", "steamRememberLogin", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
+      InternetSetCookie("http://steamcommunity.com", CookieClient.GetSteamMachineAuthCookieName(), ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
 
       // When the form is loaded, navigate to the Steam login page using the web browser control
       wbAuth.Navigate("https://steamcommunity.com/login/home/?goto=my/profile", "_self", null, "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko");
@@ -52,8 +53,22 @@ namespace IdleMaster
       // Get the URL of the page that just finished loading
       var url = wbAuth.Url.AbsoluteUri;
 
+      // If the page it just finished loading is the login page
+      if (url == "https://steamcommunity.com/login/home/?goto=my/profile" ||
+          url == "https://store.steampowered.com/login/transfer" ||
+          url == "https://store.steampowered.com//login/transfer")
+      {
+          // Get a list of cookies from the current page
+          CookieContainer container = GetUriCookieContainer(wbAuth.Url);
+          var cookies = container.GetCookies(wbAuth.Url);
+          foreach (Cookie cookie in cookies)
+          {
+              if (cookie.Name.StartsWith("steamMachineAuth"))
+                  Settings.Default.steamMachineAuth = cookie.Value;
+          }
+      }
       // If the page it just finished loading isn't the login page
-      if (url != "https://steamcommunity.com/login/home/?goto=my/profile" && url != "https://store.steampowered.com/login/transfer" && url != "https://store.steampowered.com//login/transfer" && url.StartsWith("javascript:") == false && url.StartsWith("about:") == false)
+      else if (url.StartsWith("javascript:") == false && url.StartsWith("about:") == false)
       {
 
         try


### PR DESCRIPTION
The idle master has a bug that, after it had logged in, its session
could be reset by Steam server if you go to Steam store (or community)
from web browser. You can login in web browser or already be logged in.
After you open up any page in browser, the idle master will lose its
session and ask to sign in again. But the browser doesn't lose its
session. It is because of "steamMachineAuth" cookie it has that is given
on first connection. With this cookie the idle master will not lose its
session.