### PR TITLE
Changed link to open in Steam client.

### DIFF
--- a/Source/IdleMaster/frmMain.cs
+++ b/Source/IdleMaster/frmMain.cs
@@ -710,7 +710,7 @@ namespace IdleMaster
 
         private void lblGameName_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("http://store.steampowered.com/app/" + CurrentBadge.AppId);
+            Process.Start("steam://store/" + CurrentBadge.AppId);
         }
 
         private void lnkResetCookies_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
According to https://developer.valvesoftware.com/wiki/Steam_browser_protocol use "steam" protocol to open store app page in Steam client.