### PR TITLE
Remove unnecessary imports

### DIFF
--- a/Source/IdleMaster/Statistics.cs
+++ b/Source/IdleMaster/Statistics.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace IdleMaster
+﻿namespace IdleMaster
 {
     public class Statistics
     {

--- a/Source/IdleMaster/frmMain.cs
+++ b/Source/IdleMaster/frmMain.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Xml;
 using IdleMaster.Properties;
 using Newtonsoft.Json;
 using Steamworks;

--- a/Source/IdleMaster/frmSettings.cs
+++ b/Source/IdleMaster/frmSettings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
 using IdleMaster.Properties;
-using System.Globalization;
 using System.Threading;
 using System.Text.RegularExpressions;
 

--- a/Source/IdleMaster/frmStatistics.cs
+++ b/Source/IdleMaster/frmStatistics.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace IdleMaster


### PR DESCRIPTION
These don't break functionality (And isn't really a 'fix' either, but I was unsure of how to label it) but Visual Studio 2015 suggests they be removed. There's no reason to toss in anything unneeded. Everything still compiles and functions as expected.