### PR TITLE
Save config to local dir rather than appdata

### DIFF
--- a/Source/IdleMaster/frmMain.cs
+++ b/Source/IdleMaster/frmMain.cs
@@ -566,6 +566,7 @@ namespace IdleMaster
         {
             InitializeComponent();
             AllBadges = new List<Badge>();
+            Properties.Settings.Default.ParentPath = Application.CommonAppDataPath;
         }
 
         private void frmMain_Load(object sender, EventArgs e)


### PR DESCRIPTION
This makes the portable version a bit more portable and less intrusive.