### PR TITLE
UPDATE: Adding cookie "steamLoginSecure"

### DIFF
--- a/Source/IdleMaster/CookieClient.cs
+++ b/Source/IdleMaster/CookieClient.cs
@@ -40,6 +40,7 @@ namespace IdleMaster
                         Settings.Default.steamparental = string.Empty;
                         Settings.Default.steamMachineAuth = string.Empty;
                         Settings.Default.steamRememberLogin = string.Empty;
+                        Settings.Default.steamLoginSecure = string.Empty;
                         Settings.Default.Save();
                     }
                 }
@@ -62,6 +63,7 @@ namespace IdleMaster
             cookies.Add(new Cookie("steamLogin", Settings.Default.steamLogin) { Domain = target.Host });
             cookies.Add(new Cookie("steamparental", Settings.Default.steamparental) { Domain = target.Host });
             cookies.Add(new Cookie("steamRememberLogin", Settings.Default.steamRememberLogin) { Domain = target.Host });
+            cookies.Add(new Cookie("steamLoginSecure", Settings.Default.steamLoginSecure) { Domain = target.Host });
             cookies.Add(new Cookie(GetSteamMachineAuthCookieName(), Settings.Default.steamMachineAuth) { Domain = target.Host });
             return cookies;
         }

--- a/Source/IdleMaster/Properties/Settings.Designer.cs
+++ b/Source/IdleMaster/Properties/Settings.Designer.cs
@@ -228,5 +228,17 @@ namespace IdleMaster.Properties {
                 this["OneThenMany"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string steamLoginSecure {
+            get {
+                return ((string)(this["steamLoginSecure"]));
+            }
+            set {
+                this["steamLoginSecure"] = value;
+            }
+        }
     }
 }

--- a/Source/IdleMaster/Properties/Settings.settings
+++ b/Source/IdleMaster/Properties/Settings.settings
@@ -56,5 +56,8 @@
     <Setting Name="OneThenMany" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="steamLoginSecure" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Source/IdleMaster/app.config
+++ b/Source/IdleMaster/app.config
@@ -63,6 +63,9 @@
             <setting name="OneThenMany" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="steamLoginSecure" serializeAs="String">
+                <value />
+            </setting>
         </IdleMaster.Properties.Settings>
     </userSettings>
     <runtime>

--- a/Source/IdleMaster/frmBrowser.cs
+++ b/Source/IdleMaster/frmBrowser.cs
@@ -37,6 +37,7 @@ namespace IdleMaster
       InternetSetCookie("http://steamcommunity.com", "sessionid", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
       InternetSetCookie("http://steamcommunity.com", "steamLogin", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
       InternetSetCookie("http://steamcommunity.com", "steamRememberLogin", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
+      InternetSetCookie("http://steamcommunity.com", "steamLoginSecure", ";expires=Mon, 01 Jan 0001 00:00:00 GMT");
 
       // When the form is loaded, navigate to the Steam login page using the web browser control
       wbAuth.Navigate("https://steamcommunity.com/login/home/?goto=my/profile", "_self", null, "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko");
@@ -131,6 +132,12 @@ namespace IdleMaster
           else if (cookie.Name == "steamRememberLogin")
           {
               Settings.Default.steamRememberLogin = cookie.Value;
+          }
+
+          // Save the "steamLoginSecure" cookie"
+          else if (cookie.Name == "steamLoginSecure")
+          {
+              Settings.Default.steamLoginSecure = cookie.Value;
           }
         }
 

--- a/Source/IdleMaster/frmMain.cs
+++ b/Source/IdleMaster/frmMain.cs
@@ -769,6 +769,7 @@ namespace IdleMaster
             Settings.Default.steamLogin = string.Empty;
             Settings.Default.myProfileURL = string.Empty;
             Settings.Default.steamparental = string.Empty;
+            Settings.Default.steamLoginSecure = string.Empty;
             Settings.Default.Save();
 
             // Stop the steam-idle process


### PR DESCRIPTION
Fixed bug that always "Idling complete" was shown on the screen. I discovered that when the "Remeber me" option was checked on the login screen the idle master worked fine, so I went to analyze the cookies collected at the time of login and realized that steam added a new cookie called "steamLoginSecure". After this discovery I changed the idle master code to use this cookie and everything worked fine again.